### PR TITLE
Lower os versions, add guards

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,14 +1,16 @@
-// swift-tools-version:5.6
+// swift-tools-version: 5.9
 
 import PackageDescription
 
 let package = Package(
     name: "ColorToolbox",
     platforms: [
-        .iOS(.v14),
-        .tvOS(.v14),
-        .macOS(.v11),
-        .watchOS(.v7)
+        .iOS(.v13),
+        .tvOS(.v13),
+        .macOS(.v10_15),
+        .watchOS(.v6),
+        .visionOS(.v1),
+        .macCatalyst(.v13),
     ],
     products: [
         .library(

--- a/Sources/ColorToolbox/SwiftUI/Color+ColorToolbox.swift
+++ b/Sources/ColorToolbox/SwiftUI/Color+ColorToolbox.swift
@@ -11,6 +11,7 @@
 #if canImport(SwiftUI)
 import SwiftUI
 
+@available(macOS 11.0, iOS 14.0, tvOS 14.0, macCatalyst 14.0, watchOS 7.0, *)
 extension Color {
 
     /// Relative luminance of the color.

--- a/Tests/ColorToolboxTests/SwiftUITests.swift
+++ b/Tests/ColorToolboxTests/SwiftUITests.swift
@@ -12,6 +12,7 @@ import XCTest
 import SwiftUI
 import ColorToolbox
 
+@available(macOS 11.0, iOS 14.0, tvOS 14.0, macCatalyst 14.0, watchOS 6.0, *)
 final class SwiftUITests: XCTestCase {
 
     func test_fromHex() {


### PR DESCRIPTION
Hello!

First, thanks for making this package. I've been using it for quite a while and it's great.

I'm just about to start using it in a new project, and I'd like to keep the OS version requirements low. However, I wasn't able, because this package has them just a little higher than I need. However, lowering them wasn't too hard, just had to add a few availability guards here and there.

I also bumped the package swift version. This might seem paradoxical, but I think it is reasonable to require 5.9 (Xcode 14) as a minimum. And that will allow supporting visionOS explicitly.